### PR TITLE
Switch from JSON to multipart file encoding for file upload

### DIFF
--- a/pocketbase/models/__init__.py
+++ b/pocketbase/models/__init__.py
@@ -4,3 +4,4 @@ from .external_auth import ExternalAuth
 from .log_request import LogRequest
 from .record import Record
 from .user import User
+from .file_upload import FileUpload

--- a/pocketbase/models/file_upload.py
+++ b/pocketbase/models/file_upload.py
@@ -1,0 +1,13 @@
+from httpx._types import FileTypes
+from typing import Sequence, Union
+FileUploadTypes = Union[FileTypes, Sequence[FileTypes]]
+
+
+class FileUpload:
+    def __init__(self, *args):
+        self.files: FileUploadTypes = args
+
+    def get(self, key: str):
+        if isinstance(self.files[0], Sequence):
+            return tuple((key, i) for i in self.files)
+        return ((key, self.files),)


### PR DESCRIPTION
File upload is detected when body data contains a value of class FileUpload
Remaining non-file-upload is converted to HTTP FormData
Entire message is then sent as multipart file transfer. See [httpx documentation](https://www.python-httpx.org/advanced/#multipart-file-encoding)
Supports multiple files upload into a single file field and also supports multiple file fields with different name.
solves #5 
Example how to use:
```
r = client.records.create("file_collection", {
    "name": "test123",
    "file_field_a": FileUpload(("first.bin", open("file1.bin", "rb"), "application/octet-stream"), ("second.bin", open("file2.bin", "rb"), "application/octet-stream")),
    "file_field_b": FileUpload(("only_one_file.bin", open("file3.bin", "rb"), "application/octet-stream")),
})

```