### PR TITLE
Add integration test against a sandboxed running real-world pocketbase instance

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+exclude=env,.env

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,14 +8,17 @@ on:
     branches: ["master"]
   pull_request:
     branches: ["master"]
-
+env:
+  TMP_EMAIL_DIR: /tmp/tmp_email_dir
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
@@ -28,6 +31,14 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install poetry
           python -m poetry install --with dev
+          python -m pip install flake8 pytest pytest_httpx coveralls
+          sudo apt-get install libarchive-tools -y
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Start a pocketbase database instance for api testing
+        run: |
+          mkdir $TMP_EMAIL_DIR 
+          bash ./tests/integration/pocketbase &
+          sleep 1 
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
@@ -36,4 +47,8 @@ jobs:
           poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: |
-          poetry run pytest
+          poetry run coverage run --source=pocketbase --branch -m pytest tests/ 
+          poetry run coverage report -m
+      - name: Report coverage results to coveralls.io
+        run: |
+          coveralls --verbose

--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ To execute the tests use this command:
 poetry run pytest
 ```
 
+## Sandbox integration testing
+
+A lot of real-world integration test against a sandboxed pocketbase instance will be included in the pytest when the sandbox is running (on 127.0.0.1:8090)
+to start the sandbox follow the following steps:
+```bash
+export TMP_EMAIL_DIR=`mktemp -d`  # Export temp dir used for sendmail sandbox
+bash ./tests/integration/pocketbase     # Run the pocketbase sandbox (automatically downloads the latest pocketbase instance)
+pytest  # Run test including sandbox API integration tests
+
 ## License
 
 The PocketBase Python SDK is <a href="https://github.com/vaphes/pocketbase/blob/master/LICENCE.txt">MIT licensed</a> code.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,33 @@
+from pocketbase import PocketBase
+from pocketbase.utils import ClientResponseError
+import pytest
+
+
+class State:
+    def __init__(self):
+        pass
+
+
+@pytest.fixture(scope="class")
+def state() -> State:
+    return State()
+
+
+@pytest.fixture(scope="class")
+def client() -> PocketBase:
+    try:
+        client = PocketBase("http://127.0.0.1:8090")
+        cred = {
+            "email": "68e82c0b58bd4ac0@8e8b3687496517e7.com",
+            "password": "2f199a97ac9e42e3b9e59b9d939b6e5f",
+            "passwordConfirm": "2f199a97ac9e42e3b9e59b9d939b6e5f",
+            "avatar": 8,
+        }
+        try:
+            client.admins.create(cred)
+        except ClientResponseError:
+            pass
+        client.admins.auth_with_password(cred["email"], cred["password"])
+        return client
+    except Exception:
+        pytest.skip("No Database found on 127.0.0.1:8090")

--- a/tests/integration/coverage.sh
+++ b/tests/integration/coverage.sh
@@ -1,0 +1,4 @@
+coverage run --source=pocketbase --branch -m pytest tests/ 
+coverage report -m
+flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/tests/integration/pocketbase
+++ b/tests/integration/pocketbase
@@ -1,0 +1,14 @@
+#!/bin/bash
+DBDIR=`mktemp -d`
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+#export TMP_EMAIL_DIR=`mktemp -d`
+cp ${SCRIPT_DIR}/sendmail ${DBDIR}
+chmod 755 ${DBDIR}/sendmail
+cd ${DBDIR}
+export PATH=${DBDIR}:$PATH
+#get latest release version number
+release=$(curl -IkLs -o /dev/null -w %{url_effective} https://github.com/pocketbase/pocketbase/releases/latest|grep -o "[^/]*$"| sed "s/v//g")
+echo ${release}
+wget -qO- https://github.com/pocketbase/pocketbase/releases/download/v${release}/pocketbase_${release}_linux_amd64.zip | bsdtar -xvf- --include pocketbase -C .
+chmod 755 ./pocketbase
+./pocketbase serve

--- a/tests/integration/sendmail
+++ b/tests/integration/sendmail
@@ -1,0 +1,4 @@
+#!/bin/bash
+if [[ -n "${TMP_EMAIL_DIR}" ]]; then
+cat - > ${TMP_EMAIL_DIR}/${1}
+fi

--- a/tests/integration/test_admin.py
+++ b/tests/integration/test_admin.py
@@ -1,0 +1,82 @@
+from pocketbase import PocketBase
+from pocketbase.models.admin import Admin
+from pocketbase.utils import ClientResponseError
+from uuid import uuid4
+import pytest
+from os import environ, path
+from time import sleep
+
+
+class TestAdminService:
+    def test_login(self, client: PocketBase):
+        assert isinstance(client.auth_store.model, Admin)
+
+    def test_create_admin(self, client: PocketBase, state):
+        state.email = "%s@%s.com" % (uuid4().hex[:16], uuid4().hex[:16])
+        state.password = uuid4().hex
+        state.admin = client.admins.create(
+            {
+                "email": state.email,
+                "password": state.password,
+                "passwordConfirm": state.password,
+                "avatar": 8,
+            }
+        )
+        # should stay logged in as previous admin
+        assert client.auth_store.model.id != state.admin.id
+
+    def test_login_as_created_admin(self, client: PocketBase, state):
+        client.admins.auth_with_password(state.email, state.password)
+        assert client.auth_store.model.id == state.admin.id
+
+    def test_update_admin(self, client: PocketBase, state):
+        state.new_email = "%s@%s.com" % (uuid4().hex[:16], uuid4().hex[:16])
+        new_password = uuid4().hex
+        client.admins.update(
+            state.admin.id,
+            {
+                "email": state.new_email,
+                "password": new_password,
+                "passwordConfirm": new_password,
+                "avatar": 8,
+            },
+            query_params={},
+        )
+        # Pocketbase will have invalidated the auth token on changing logged-in user
+        client.admins.auth_with_password(state.new_email, new_password)
+
+    def test_admin_password_reset(self, client: PocketBase, state):
+        assert client.admins.requestPasswordReset(state.new_email)
+        sleep(0.1)
+        mail = environ.get("TMP_EMAIL_DIR") + f"/{state.new_email}"
+        assert path.exists(mail)
+        for line in open(mail).readlines():
+            if "/confirm-password-reset/" in line:
+                token = line.split("/confirm-password-reset/", 1)[1].split('"')[0]
+        assert len(token) > 10
+        new_password = uuid4().hex
+        assert client.admins.confirmPasswordReset(token, new_password, new_password)
+        client.admins.auth_with_password(state.new_email, new_password)
+
+    def test_delete_admin(self, client: PocketBase, state):
+        client.admins.delete(state.admin.id, query_params={})
+
+
+def test_invalid_login_exception(client):
+    with pytest.raises(ClientResponseError) as exc:
+        client.admins.auth_with_password(uuid4().hex, uuid4().hex)
+    assert exc.value.status == 400  # invalid login
+
+
+def test_connection_error_exception():
+    client = PocketBase("http://127.0.0.2:9090")
+    with pytest.raises(ClientResponseError) as exc:
+        client.admins.auth_with_password(uuid4().hex, uuid4().hex)
+    assert isinstance(exc.value, ClientResponseError)
+
+
+def test_auth_refresh(client):
+    oldid = client.auth_store.model.id
+    ar = client.admins.authRefresh()
+    assert client.auth_store.token == ar.token
+    assert client.auth_store.model.id == oldid

--- a/tests/integration/test_collection.py
+++ b/tests/integration/test_collection.py
@@ -1,0 +1,94 @@
+from pocketbase import PocketBase
+from pocketbase.utils import ClientResponseError
+from pocketbase.models.collection import Collection
+
+from uuid import uuid4
+import pytest
+
+
+class TestCollectionService:
+    def test_create(self, client: PocketBase, state):
+        state.collection = client.collections.create(
+            {
+                "name": uuid4().hex,
+                "type": "base",
+                "schema": [
+                    {
+                        "name": "title",
+                        "type": "text",
+                        "required": True,
+                        "options": {
+                            "min": 10,
+                        },
+                    },
+                ],
+            }
+        )
+        assert isinstance(state.collection, Collection)
+        assert state.collection.is_base
+        assert not state.collection.is_auth()
+        assert not state.collection.is_single()
+
+    def test_update(self, client: PocketBase, state):
+        client.collections.update(
+            state.collection.id,
+            {
+                "name": uuid4().hex,
+                "schema": [
+                    {
+                        "name": "title",
+                        "type": "text",
+                        "required": True,
+                        "options": {
+                            "min": 10,
+                        },
+                    },
+                    {
+                        "name": "status",
+                        "type": "bool",
+                    },
+                ],
+            },
+        )
+
+    def test_delete(self, client: PocketBase, state):
+        client.collections.delete(state.collection.id)
+        with pytest.raises(ClientResponseError) as exc:
+            client.collections.delete(state.collection.id, uuid4().hex)
+        assert exc.value.status == 404  # double already deleted
+
+
+def test_delete_nonexisting_exception(client):
+    with pytest.raises(ClientResponseError) as exc:
+        client.collections.delete(uuid4().hex, uuid4().hex)
+    assert exc.value.status == 404  # delete nonexisting
+
+
+def test_get_nonexisting_exception(client):
+    with pytest.raises(ClientResponseError) as exc:
+        client.collections.get_one(uuid4().hex)
+    assert exc.value.status == 404
+
+
+def test_import_collection(client):
+    data = [
+        {
+            "name": uuid4().hex,
+            "schema": [
+                {
+                    "name": "status",
+                    "type": "bool",
+                },
+            ],
+        },
+        {
+            "name": uuid4().hex,
+            "schema": [
+                {
+                    "name": "title",
+                    "type": "text",
+                },
+            ],
+        },
+    ]
+    assert client.collections.import_collections(data)

--- a/tests/integration/test_files.py
+++ b/tests/integration/test_files.py
@@ -1,0 +1,114 @@
+from pocketbase import PocketBase
+from pocketbase.utils import ClientResponseError
+from pocketbase.client import FileUpload
+import httpx
+from random import getrandbits
+
+from uuid import uuid4
+import pytest
+
+
+class TestFileService:
+    def test_init_collection(self, client: PocketBase, state):
+        srv = client.collections
+        # create collection
+        schema = [
+            {
+                "name": "title",
+                "type": "text",
+                "required": True,
+            },
+            {
+                "name": "image",
+                "type": "file",
+                "required": False,
+                "options": {
+                    "maxSelect": 3,
+                    "maxSize": 5242880,
+                    "mimeTypes": [
+                        "application/octet-stream",
+                        "text/plain",
+                    ],
+                },
+            },
+        ]
+        state.coll = srv.create(
+            {
+                "name": uuid4().hex,
+                "type": "base",
+                "schema": schema,
+            }
+        )
+
+    def test_create_three_file_record(self, client: PocketBase, state):
+        name1 = uuid4().hex
+        name2 = uuid4().hex
+        name3 = uuid4().hex
+        acontent = uuid4().hex
+        bcontent = getrandbits(1024 * 8).to_bytes(1024, "little")
+        ccontent = uuid4().hex
+        record = client.collection(state.coll.id).create(
+            {
+                "title": uuid4().hex,
+                "image": FileUpload(
+                    (name1 + ".txt", acontent, "text/plain"),
+                    (name2 + ".txt", bcontent, "application/octet-stream"),
+                    (name3 + ".txt", ccontent, "text/plain"),
+                ),
+            }
+        )
+        state.recordid = record.id
+        assert len(record.image) == 3
+        for fn in record.image:
+            if fn.startswith(name2):
+                break
+        state.recordfn = fn
+
+        rel = client.collection(state.coll.id).get_one(record.id)
+        assert len(rel.image) == 3
+
+        r = httpx.get(client.get_file_url(rel, fn, query_params={}))
+        assert r.status_code == 200
+        assert r.content == bcontent
+
+    def test_remove_file_from_record(self, client: PocketBase, state):
+        record = client.collection(state.coll.id).get_one(state.recordid)
+        assert len(record.image) == 3
+        # delete some of the files from record but keep the file named "state.filename"
+        get_record = client.collection(state.coll.id).update(
+            record.id, {"image": [state.recordfn]}
+        )
+        assert record.image != get_record.image
+        assert len(get_record.image) == 1
+
+    def test_create_one_file_record(self, client: PocketBase, state):
+        name1 = uuid4().hex
+        acontent = uuid4().hex
+        record = client.collection(state.coll.id).create(
+            {
+                "title": uuid4().hex,
+                "image": FileUpload(name1 + ".txt", acontent, "text/plain"),
+            }
+        )
+        assert len(record.image) == 1
+        for fn in record.image:
+            assert fn.startswith(name1)
+
+        rel = client.collection(state.coll.id).get_one(record.id)
+        assert len(rel.image) == 1
+
+        r = httpx.get(client.get_file_url(rel, rel.image[0], query_params={}))
+        assert r.status_code == 200
+        assert r.content.decode("utf-8") == acontent
+
+    def test_create_without_file_record2(self, client: PocketBase, state):
+        record = client.collection(state.coll.id).create(
+            {
+                "title": uuid4().hex,
+                "image": None,
+            }
+        )
+        assert len(record.image) == 0
+
+        rel = client.collection(state.coll.id).get_one(record.id)
+        assert len(rel.image) == 0

--- a/tests/integration/test_local_auth_store.py
+++ b/tests/integration/test_local_auth_store.py
@@ -1,0 +1,49 @@
+from pocketbase import PocketBase
+from pocketbase.models.admin import Admin
+from pocketbase.utils import ClientResponseError
+from pocketbase.stores.local_auth_store import LocalAuthStore
+from uuid import uuid4
+import pytest
+import tempfile
+
+
+class TestLocalAuthStore:
+    def test_save(self, state):
+        state.tmp = tempfile.mkdtemp()
+        state.token = uuid4().hex
+        state.admin = Admin(
+            {
+                "id": "38wgsiz3pdsu1j7",
+                "avatar": 8,
+                "email": "68e82c0b58bd4ac0@8e8b3687496517e7.com",
+            }
+        )
+        store = LocalAuthStore(filepath=state.tmp)
+        store.save(state.token, state.admin)
+
+    def test_load(self, state):
+        store = LocalAuthStore(filepath=state.tmp)
+        assert store.token == state.token
+        assert store.model.email == state.admin.email
+
+    def test_clear(self, state):
+        store = LocalAuthStore(filepath=state.tmp)
+        store.clear()
+        assert store.token != state.token
+        assert store.model is None
+
+
+def test_invalid_login_exception(client):
+    with pytest.raises(ClientResponseError) as exc:
+        client.admins.auth_with_password(uuid4().hex, uuid4().hex)
+    assert exc.value.status == 400  # invalid login
+
+
+def test_local_store_integration(client):
+    tmp = tempfile.mkdtemp()
+    l_store = LocalAuthStore(filepath=tmp)
+    la_client = PocketBase(client.base_url, auth_store=l_store)
+    with pytest.raises(ClientResponseError):
+        la_client.admins.authRefresh()
+    la_client.auth_store.save(client.auth_store.token, client.auth_store.model)
+    la_client.admins.authRefresh()

--- a/tests/integration/test_log_service.py
+++ b/tests/integration/test_log_service.py
@@ -1,0 +1,19 @@
+from pocketbase import PocketBase
+
+
+class TestLogService:
+    def test_get_request_list(self, client: PocketBase, state):
+        state.list = client.logs.get_request_list()
+
+    def test_get_request(self, client: PocketBase, state):
+        if len(state.list.items) > 0:
+            v = state.list.items[0]
+            r = client.logs.get_request(v.id)
+            assert v.id == r.id
+            assert v.created == r.created
+
+    def test_log_request_stats(self, client: PocketBase, state):
+        state.stats = client.logs.get_requests_stats()
+        assert len(state.stats) > 0
+        for v in state.stats:
+            assert v.total > 0

--- a/tests/integration/test_record.py
+++ b/tests/integration/test_record.py
@@ -1,0 +1,142 @@
+from pocketbase import PocketBase
+from pocketbase.utils import ClientResponseError
+from pocketbase.client import FileUpload
+import httpx
+from random import getrandbits
+
+from uuid import uuid4
+import pytest
+
+
+class TestRecordService:
+    def test_init_collection(self, client: PocketBase, state):
+        srv = client.collections
+        # create collection
+        schema = [
+            {
+                "name": "title",
+                "type": "text",
+                "required": True,
+            },
+        ]
+        state.coll = srv.create(
+            {
+                "name": uuid4().hex,
+                "type": "base",
+                "schema": schema,
+            }
+        )
+        schema.append(
+            {
+                "name": "rel",
+                "type": "relation",
+                "required": False,
+                "options": {
+                    "collectionId": state.coll.id,
+                    "cascadeDelete": False,
+                    "maxSelect": 1,
+                },
+            },
+        )
+        state.coll = srv.update(state.coll.id, {"schema": schema})
+
+    def test_create_record(self, client: PocketBase, state):
+        bname = uuid4().hex
+        state.record = client.collection(state.coll.id).create(
+            {
+                "title": bname,
+            }
+        )
+        assert state.record.title == bname
+
+    def test_create_multiple_record(self, client: PocketBase, state):
+        state.chained_records = [
+            state.record.id,
+        ]
+        for _ in range(10):
+            state.chained_records.append(
+                client.collection(state.coll.id)
+                .create(
+                    {
+                        "title": uuid4().hex,
+                        "rel": state.chained_records[-1],
+                    }
+                )
+                .id
+            )
+
+    def test_get_record(self, client: PocketBase, state):
+        state.get_record = client.collection(state.coll.id).get_one(state.record.id)
+        assert state.get_record.title is not None
+        assert state.record.title == state.get_record.title
+        assert not state.get_record.is_new
+        assert state.get_record.id in f"{state.get_record}"
+        assert state.get_record.id in repr(state.get_record)
+
+    def test_get_record_expand(self, client: PocketBase, state):
+        rel = client.collection(state.coll.id).get_one(
+            state.chained_records[-1], {"expand": "rel.rel.rel.rel.rel.rel"}
+        )
+        for i, r in enumerate(reversed(state.chained_records)):
+            assert rel.id == r
+            if i > 5:
+                break
+            rel = rel.expand["rel"]
+
+    def test_get_record_expand_full_list(self, client: PocketBase, state):
+        rel = client.collection(state.coll.id).get_full_list(
+            query_params={"expand": "rel.rel"}
+        )
+        i = 0
+        for r in rel:
+            while r != None:
+                if hasattr(r, "expand"):
+                    if "rel" in r.expand:
+                        i += 1
+                        r = r.expand["rel"]
+                        continue
+                r = None
+        assert i == 19
+
+    def test_get_list(self, client: PocketBase, state):
+        val = client.collection(state.coll.id).get_list()
+        assert len(val.items) > 10
+
+    def test_get_full_list(self, client: PocketBase, state):
+        items = client.collection(state.coll.id).get_full_list(batch=1)
+        cnt = 0
+        for i in items:
+            if i.title == state.get_record.title:
+                cnt += 1
+        assert cnt == 1
+
+    def test_get_first_list_item(self, client: PocketBase, state):
+        return
+        items = client.collection(state.coll.id).get_first_list_item(
+            'title="%s"' % state.get_record.title
+        )
+        assert items.title == state.get_record.title
+
+    def test_update_record(self, client: PocketBase, state):
+        assert state.record.title == state.get_record.title
+        state.get_record = client.collection(state.coll.id).update(
+            state.record.id, {"title": uuid4().hex}
+        )
+        assert state.record.title != state.get_record.title
+
+    def test_delete_record(self, client: PocketBase, state):
+        client.collection(state.coll.id).delete(state.record.id)
+        # deleting already deleted record should give 404
+        with pytest.raises(ClientResponseError) as exc:
+            client.collection(state.coll.id).get_one(state.record.id)
+        assert exc.value.status == 404
+
+    def test_delete_nonexisting_exception(self, client: PocketBase, state):
+        with pytest.raises(ClientResponseError) as exc:
+            client.collection(state.coll.id).delete(uuid4().hex, uuid4().hex)
+        assert exc.value.status == 404  # delete nonexisting
+
+    def test_get_nonexisting_exception(self, client: PocketBase, state):
+        with pytest.raises(ClientResponseError) as exc:
+            client.collection(state.coll.id).get_one(uuid4().hex)
+        assert exc.value.status == 404

--- a/tests/integration/test_record_auth.py
+++ b/tests/integration/test_record_auth.py
@@ -1,0 +1,114 @@
+from pocketbase import PocketBase
+from pocketbase.models.record import Record
+from pocketbase.models.admin import Admin
+from pocketbase.utils import ClientResponseError
+
+from uuid import uuid4
+import pytest
+from time import sleep
+from os import environ, path
+
+
+class TestRecordAuthService:
+    def test_create_user(self, client: PocketBase, state):
+        state.email = "%s@%s.com" % (uuid4().hex[:16], uuid4().hex[:16])
+        state.password = uuid4().hex
+        state.user = client.collection("users").create(
+            {
+                "email": state.email,
+                "password": state.password,
+                "passwordConfirm": state.password,
+                "verified": False,
+            }
+        )
+        # should stay logged in as previous admin
+        assert isinstance(client.auth_store.model, Admin)
+
+    def test_login_user(self, client: PocketBase, state):
+        oldtoken = client.auth_store.token
+        client.auth_store.clear()
+        client.collection("users").auth_with_password(state.email, state.password)
+        # should now be logged in as new user
+        assert isinstance(client.auth_store.model, Record)
+        assert client.auth_store.model.id == state.user.id
+        # should have gotten a new token
+        assert client.auth_store.token != oldtoken
+
+    def test_auth_refresh(self, client):
+        client.collection("users").authRefresh()
+
+    def test_confirm_email(self, client: PocketBase, state):
+        # new_email = "%s@%s.com" % (uuid4().hex[:16], uuid4().hex[:16])
+        print(state.email)
+        sleep(0.2)
+        assert client.collection("users").requestVerification(state.email)
+        sleep(0.2)
+        mail = environ.get("TMP_EMAIL_DIR") + f"/{state.email}"
+        assert path.exists(mail)
+        print("START")
+        for line in open(mail).readlines():
+            print(line)
+            if "/confirm-verification/" in line:
+                token = line.split("/confirm-verification/", 1)[1].split('"')[0]
+        assert len(token) > 10
+        assert client.collection("users").confirmVerification(token)
+
+    def test_change_password(self, client: PocketBase, state):
+        new_password = uuid4().hex
+        client.collection("users").update(
+            state.user.id,
+            {
+                "oldPassword": state.password,
+                "password": new_password,
+                "passwordConfirm": new_password,
+            },
+        )
+        # Pocketbase will have invalidated the auth token on changing logged-in user
+        client.collection("users").auth_with_password(state.email, new_password)
+        state.password = new_password
+
+    def test_change_email(self, client: PocketBase, state):
+        new_email = "%s@%s.com" % (uuid4().hex[:16], uuid4().hex[:16])
+        assert client.collection("users").requestEmailChange(new_email)
+        sleep(0.1)
+        mail = environ.get("TMP_EMAIL_DIR") + f"/{new_email}"
+        assert path.exists(mail)
+        for line in open(mail).readlines():
+            if "/confirm-email-change/" in line:
+                token = line.split("/confirm-email-change/", 1)[1].split('"')[0]
+        assert len(token) > 10
+        assert client.collection("users").confirmEmailChange(token, state.password)
+        client.collection("users").auth_with_password(new_email, state.password)
+        state.email = new_email
+
+    def test_request_password_reset(self, client: PocketBase, state):
+        client.auth_store.clear()
+        state.password = uuid4().hex
+        assert client.collection("users").requestPasswordReset(state.email)
+        sleep(0.1)
+        mail = environ.get("TMP_EMAIL_DIR") + f"/{state.email}"
+        assert path.exists(mail)
+        for line in open(mail).readlines():
+            if "/confirm-password-reset/" in line:
+                token = line.split("/confirm-password-reset/", 1)[1].split('"')[0]
+        assert len(token) > 10
+        assert client.collection("users").confirmPasswordReset(
+            token, state.password, state.password
+        )
+        client.collection("users").auth_with_password(state.email, state.password)
+
+    def test_delete_user(self, client: PocketBase, state):
+        client.collection("users").delete(state.user.id)
+
+
+def test_invalid_login_exception(client):
+    with pytest.raises(ClientResponseError) as exc:
+        client.collection("users").auth_with_password(uuid4().hex, uuid4().hex)
+    assert exc.value.status == 400
+
+
+def test_list_auth_methods(client):
+    val = client.collection("users").list_auth_methods()
+    assert isinstance(val.username_password, bool)
+    assert isinstance(val.email_password, bool)
+    assert isinstance(val.auth_providers, list)

--- a/tests/integration/test_record_event.py
+++ b/tests/integration/test_record_event.py
@@ -1,0 +1,87 @@
+from pocketbase import PocketBase
+from uuid import uuid4
+from pocketbase.services import RecordService
+from pocketbase.services.realtime_service import MessageData
+from pocketbase.models import Record
+
+from time import sleep
+
+
+class TestRecordEventService:
+    def test_init_collection(self, client: PocketBase, state):
+        # create collection
+        schema = [
+            {
+                "name": "title",
+                "type": "text",
+                "required": True,
+            },
+        ]
+        state.coll = client.collections.create(
+            {
+                "name": uuid4().hex,
+                "type": "base",
+                "schema": schema,
+            }
+        )
+        state.c: RecordService = client.collection(state.coll.id)
+
+    def test_subscribe_event(self, client: PocketBase, state):
+        c: RecordService = state.c
+        state.test_subscribe_event = None
+
+        def callback(e: MessageData):
+            state.test_subscribe_event = e
+
+        c.subscribe(callback)
+        sleep(0.1)
+        for _ in range(2):
+            state.record = state.c.create({"title": uuid4().hex})
+            sleep(0.1)
+            e: MessageData = state.test_subscribe_event
+            assert e.record.collection_id == state.coll.id
+            assert e.record.id == state.record.id
+        c.unsubscribe()
+        c.unsubscribe()
+        client.realtime.unsubscribe([])
+        sleep(0.1)
+        for _ in range(2):
+            state.c.create({"title": uuid4().hex})
+            sleep(0.1)
+            # e should now not be mutated any more as we are unsubscribed
+            e: MessageData = state.test_subscribe_event
+            assert e.record.collection_id == state.coll.id
+            assert e.record.id == state.record.id
+
+    def test_subscribe_single_record(self, client: PocketBase, state):
+        c: RecordService = state.c
+        r: Record = state.record
+        state.test_subscribe_event2 = None
+
+        def callback_ex(e: MessageData):
+            raise Exception("This Callback should be never called")
+
+        def callback(e: MessageData):
+            state.test_subscribe_event2 = e
+
+        c.subscribeOne(r.id, callback_ex)
+        # subscribing a second time should erase first subscription (for code coverage)
+        c.subscribeOne(r.id, callback)
+        sleep(0.1)
+        for _ in range(2):
+            r = c.update(r.id, {"title": uuid4().hex})
+            sleep(0.1)
+            e: MessageData = state.test_subscribe_event2
+            assert e.record.collection_id == state.coll.id
+            assert e.record.id == r.id
+            state.test_subscribe_event2.record.id = "abc"
+        c.unsubscribe(r.id, r.id)
+        sleep(0.1)
+
+        for _ in range(2):
+            c.update(r.id, {"title": uuid4().hex})
+            sleep(0.1)
+            # e should now not be mutated any more as we are unsubscribed
+            e: MessageData = state.test_subscribe_event2
+            assert e.record.collection_id == state.coll.id
+            assert e.record.id == "abc"

--- a/tests/integration/test_settings.py
+++ b/tests/integration/test_settings.py
@@ -1,0 +1,31 @@
+from pocketbase import PocketBase
+import pytest
+from pocketbase.utils import ClientResponseError
+from uuid import uuid4
+from os import environ, path
+
+
+class TestSettingsService:
+    def test_write_setting(self, client: PocketBase, state):
+        state.appname = uuid4().hex
+        client.settings.update(
+            {
+                "meta": {
+                    "appName": state.appname,
+                },
+            }
+        )
+
+    def test_read_all(self, client: PocketBase, state):
+        settings = client.settings.get_all()
+        assert state.appname == settings["meta"]["appName"]
+
+    def test_email(self, client: PocketBase, state):
+        addr = uuid4().hex
+        assert client.settings.test_email(f"settings@{addr}.com", "verification")
+        assert path.exists(environ.get("TMP_EMAIL_DIR") + f"/settings@{addr}.com")
+
+    def test_s3(self, client: PocketBase, state):
+        with pytest.raises(ClientResponseError) as exc:
+            client.settings.test_s3()
+        assert exc.value.status == 400


### PR DESCRIPTION
Hi,
I added now a total of 53 extra integration tests that can run against a sandboxed pocketbase database instance. 
Documentation for how to start a sandbox is in README.md and required tooling scripts are in the same folder as the tests

The sandbox script download pocketbase executable from the official repository and executes it in a temporary folder.
This allows to run pytests against this instance in order to verify the whole set of possible workflows. 

The tests reveal several bugs in the current `vaphes/master` I can fix them in a seperate PR. 
I removed all bugfixes that so this PR only adds additional tests without changing the pocketbase library at all. I have already bugfixes for all 11 failing tests ready. 

Best,
Martin