### PR TITLE
Added ability to set client timeout.

### DIFF
--- a/pocketbase/client.py
+++ b/pocketbase/client.py
@@ -35,10 +35,12 @@ class Client:
         base_url: str = "/",
         lang: str = "en-US",
         auth_store: BaseAuthStore | None = None,
+        timeout: float = 120,
     ) -> None:
         self.base_url = base_url
         self.lang = lang
         self.auth_store = auth_store or BaseAuthStore()  # LocalAuthStore()
+        self.timeout = timeout
         # services
         self.admins = AdminService(self)
         self.collections = CollectionService(self)
@@ -94,7 +96,7 @@ class Client:
                 json=body,
                 data=data,
                 files=files,
-                timeout=120,
+                timeout=self.timeout,
             )
         except Exception as e:
             raise ClientResponseError(


### PR DESCRIPTION
I'm using pocketbase to push telemetry over a 4G connection. Sometimes the requests fail due to clitches in connectivity. I find 120 sec is too long to block before retrying; so I have added the ability to set a timeout when creating the client. 