### PR TITLE
Revert "adding dataclass to record model (#33)"

### DIFF
--- a/pocketbase/models/record.py
+++ b/pocketbase/models/record.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 from pocketbase.models.utils.base_model import BaseModel
 from pocketbase.utils import camel_to_snake
-from dataclasses import dataclass, field
 
-@dataclass
+
 class Record(BaseModel):
     collection_id: str
-    collection_name: str = ""
-    expand: dict = field(default_factory=dict)
+    collection_name: str
+    expand: dict
 
     def load(self, data: dict) -> None:
         super().load(data)


### PR DESCRIPTION
Record class was broken after this commit. 
See https://github.com/vaphes/pocketbase/issues/37.