### PR TITLE
Fixes #47 local_auth_store file not found error

### DIFF
--- a/pocketbase/stores/local_auth_store.py
+++ b/pocketbase/stores/local_auth_store.py
@@ -52,9 +52,12 @@ class LocalAuthStore(BaseAuthStore):
             pickle.dump(value, f)
 
     def _storage_get(self, key: str) -> Any:
-        with open(key, "rb") as f:
-            value = pickle.load(f)
-        return value
+        try:
+            with open(key, "rb") as f:
+                value = pickle.load(f)
+            return value
+        except FileNotFoundError:
+            return {}
 
     def _storage_remove(self, key: str) -> None:
         if os.path.exists(key):


### PR DESCRIPTION
fixes issue #47 
treat a missing LocalAuthStore storage file just like an empty LocalAuthStore storage file