### PR TITLE
Fixes #49 uploading a single FileUpload record 

### DIFF
--- a/pocketbase/models/file_upload.py
+++ b/pocketbase/models/file_upload.py
@@ -9,6 +9,6 @@ class FileUpload:
         self.files: FileUploadTypes = args
 
     def get(self, key: str):
-        if isinstance(self.files[0], Sequence):
+        if isinstance(self.files[0], Sequence) and not isinstance(self.files[0], str):
             return tuple((key, i) for i in self.files)
         return ((key, self.files),)


### PR DESCRIPTION
The FileUpload.get() method did not sufficiently distinguish between list containing three values (filename,content,mimetype) and a list of (lists containing those three values) 

It turns out that both `list` and `str` are both instances of `Sequence` 

Fixes issue #49