### PR TITLE
Fixes #53 AdminService delete + update not working issue

### DIFF
--- a/pocketbase/services/admin_service.py
+++ b/pocketbase/services/admin_service.py
@@ -23,12 +23,12 @@ class AdminService(CrudService):
     def base_crud_path(self) -> str:
         return "/api/admins"
 
-    def update(self, id: str, body_params: dict, query_params: dict) -> BaseModel:
+    def update(self, id: str, body_params: dict, query_params={}) -> BaseModel:
         """
         If the current `client.auth_store.model` matches with the updated id,
         then on success the `client.auth_store.model` will be updated with the result.
         """
-        item = super(AdminService).update(id, body_params)
+        item = super().update(id, body_params=body_params, query_params=query_params)
         try:
             if (
                 self.client.auth_store.model.collection_id is not None
@@ -39,12 +39,12 @@ class AdminService(CrudService):
             pass
         return item
 
-    def delete(self, id: str, body_params: dict, query_params: dict) -> BaseModel:
+    def delete(self, id: str, query_params={}) -> BaseModel:
         """
         If the current `client.auth_store.model` matches with the deleted id,
         then on success the `client.auth_store` will be cleared.
         """
-        item = super(AdminService).delete(id, body_params)
+        item = super().delete(id, query_params=query_params)
         try:
             if (
                 self.client.auth_store.model.collection_id is not None

--- a/pocketbase/services/record_service.py
+++ b/pocketbase/services/record_service.py
@@ -92,7 +92,7 @@ class RecordService(CrudService):
         If the current `client.auth_store.model` matches with the updated id, then
         on success the `client.auth_store.model` will be updated with the result.
         """
-        item = super().update(id, body_params)  # super(Record).update
+        item = super().update(id, body_params=body_params, query_params=query_params)
         try:
             if (
                 self.client.auth_store.model.collection_id is not None
@@ -103,12 +103,12 @@ class RecordService(CrudService):
             pass
         return item
 
-    def delete(self, id: str, body_params: dict = {}, query_params: dict = {}):
+    def delete(self, id: str, query_params: dict = {}):
         """
         If the current `client.auth_store.model` matches with the deleted id,
         then on success the `client.auth_store` will be cleared.
         """
-        success = super().delete(id, body_params)  # super(Record).delete
+        success = super().delete(id, query_params)
         try:
             if (
                 success


### PR DESCRIPTION
 - Fixes issue #53  Error: `AttributeError: 'super' object has no attribute 'update'` 
 - remove body_params from delete as this function has no body_params 
 - set query_params default value to empty dict to be consistent with JS client
 - Fix body_params accidentally being passed to underlying function as query_params argument (also fixed same in recordservice)