### PR TITLE
Add an error message for trying to connect over HTTP with HSTS enabled

### DIFF
--- a/pocketbase/services/record_service.py
+++ b/pocketbase/services/record_service.py
@@ -176,6 +176,10 @@ class RecordService(CrudService):
                 "headers": {"Authorization": ""},
             },
         )
+
+        if response_data is None:
+            raise ConnectionError("No response from PocketBase. Make sure you are using HTTPS if required.")
+
         return self.auth_response(response_data)
 
     def auth_with_oauth2(


### PR DESCRIPTION
## Previous error message for this situation:
![Screenshot 2023-07-13 at 6 34 18 PM](https://github.com/vaphes/pocketbase/assets/105258719/82f3cea5-0245-4cc0-bf08-a16dc360f8d2)


The previous error message was not related to what I was doing wrong, so it took me a while to realize that the error was coming from the fact that I forgot to use HTTPS. 