### PR TITLE
fixes #65 issue when expanding list of multiple relations

### DIFF
--- a/pocketbase/models/record.py
+++ b/pocketbase/models/record.py
@@ -19,6 +19,8 @@ class Record(BaseModel):
 
     @classmethod
     def parse_expanded(cls, data: dict):
+        if isinstance(data, list):
+            return [cls(a) for a in data]
         return cls(data)
 
     def load_expanded(self) -> None:


### PR DESCRIPTION
This adds both a integration test case for multiple relation expansion as well as resolves #65  

we did not handle the case where the expansion is a list of records instead of a single record directly

Note: this only pushes the uncertainty down to the next layer. 
Now the value of `expand["xxx"]` can either be 
- not present in the map expand at all if there is no relation 
- a value of type Record if there actually is a single relation (even if pocketbase theoretically allows to set more than one relation)
- a value of type List[Record] if there are actually two or more relations