### PR TITLE
Introduce backups service.

### DIFF
--- a/pocketbase/models/__init__.py
+++ b/pocketbase/models/__init__.py
@@ -1,8 +1,9 @@
 from .admin import Admin
+from .backups import Backup
 from .collection import Collection
 from .external_auth import ExternalAuth
 from .log_request import LogRequest
 from .record import Record
 from .file_upload import FileUpload
 
-__all__ = ["Admin", "Collection", "ExternalAuth", "LogRequest", "Record", "FileUpload"]
+__all__ = ["Admin", "Backup", "Collection", "ExternalAuth", "LogRequest", "Record", "FileUpload"]

--- a/pocketbase/models/backups.py
+++ b/pocketbase/models/backups.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import datetime
+
+from pocketbase.models.utils import BaseModel
+from pocketbase.utils import to_datetime
+
+
+class Backup(BaseModel):
+    key: str
+    modified: str | datetime.datetime
+    size: int
+
+    def load(self, data: dict) -> None:
+        super().load(data)
+        self.key = data.get("key", "")
+        self.modified = to_datetime(data.pop("modified", ""))
+        self.size = data.get("size", 0)

--- a/pocketbase/services/backups_service.py
+++ b/pocketbase/services/backups_service.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pocketbase.models import Backup
+from pocketbase.services.utils import BaseService
+
+
+class BackupsService(BaseService):
+    def decode(self, data: dict) -> Backup:
+        return Backup(data)
+
+    def base_path(self) -> str:
+        return "/api/backups"
+
+    def create(self, name: str):
+        # The backups service create method does not return an object.
+        self.client.send(
+            self.base_path(),
+            {"method": "POST", "body": {"name": name}},
+        )
+
+    def get_full_list(self, query_params: dict = {}) -> list[Backup]:
+        response_data = self.client.send(self.base_path(), {"method": "GET", "params": query_params})
+        return [self.decode(item) for item in response_data]
+
+    def download(self, key: str, file_token: str = None) -> bytes:
+        if file_token is None:
+            file_token = self.client.get_file_token()
+        return self.client.send_raw("%s/%s" % (self.base_path(), key),
+                                    {"method": "GET", "params": {"token": file_token}})
+
+    def delete(self, key: str):
+        self.client.send("%s/%s" % (self.base_path(), key), {"method": "DELETE"})

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,5 @@
+import logging
+
 from pocketbase import PocketBase
 from pocketbase.utils import ClientResponseError
 import pytest

--- a/tests/integration/test_backups.py
+++ b/tests/integration/test_backups.py
@@ -1,0 +1,36 @@
+import datetime
+from uuid import uuid4
+
+from pocketbase import PocketBase
+
+
+class TestBackupsService:
+    def test_create_list_download_and_delete(self, client: PocketBase, state):
+        state.backup_name = "%s.zip" % (uuid4().hex[:16],)
+        client.backups.create(state.backup_name)
+
+        try:
+            # Find new backup in list of all backups
+            for backup in client.backups.get_full_list():
+                if backup.key == state.backup_name:
+                    state.backup = backup
+                    assert isinstance(backup.modified, datetime.datetime)
+                    assert backup.size > 0
+                    break
+            else:
+                self.fail("Backup %s not found in list of all backups" % (state.backup_name,))
+
+            # Download the backup
+            data = client.backups.download(state.backup_name)
+            assert isinstance(data, bytes)
+            assert len(data) == state.backup.size
+        finally:
+            # Cleanup
+            client.backups.delete(state.backup_name)
+
+            # Check that it was deleted
+            for backup in client.backups.get_full_list():
+                if backup.key == state.backup_name:
+                    self.fail("Backup %s still found in list of all backups" % (state.backup_name,))
+                    break
+


### PR DESCRIPTION
* Support create(), get_full_list(), download() and delete()

* Refactored Client.send() to support binary responses.

* Added Client.send_raw() which returns raw bytes from HTTP response.

It was not possible to support any of the standard API CRUD operations provided by the `BaseCrudService` on account of the Backups API returning very different structures in most requests and responses. It would have required changing the interface for the class which seemed dangerous. Therefore, the API for Backups is a little more bespoke.

The tests for the Backups API is also a little different in that it seems like a somewhat heavier type of operation than other operations and lent itself better to doing verification that the underlying APIs were in fact called.

The `download` interface also has an optional parameter for `file_token`. Not providing one is easier to use, but could create a poor usage pattern as it is more inefficient for multiple download calls. If the reviewer could provide feedback as to whether it is desirable or acceptable it would be welcome.