### PR TITLE
Add AuthProviderInfo.display_name

### DIFF
--- a/pocketbase/services/record_service.py
+++ b/pocketbase/services/record_service.py
@@ -28,6 +28,7 @@ class RecordAuthResponse:
 @dataclass
 class AuthProviderInfo:
     name: str
+    display_name: str
     state: str
     code_verifier: str
     code_challenge: str


### PR DESCRIPTION
Fix `client.collection('users').list_auth_methods()` failure because of missing AuthProviderInfo.display_name