### PR TITLE
Update admin_service.py

### DIFF
--- a/pocketbase/services/admin_service.py
+++ b/pocketbase/services/admin_service.py
@@ -27,7 +27,7 @@ class AdminService(CrudService[Admin]):
         return Admin(data)
 
     def base_crud_path(self) -> str:
-        return "/api/collections/_superusers"
+        return "/api/admins"
 
     def update(
         self,


### PR DESCRIPTION
This is an update for the new Pocketbase v0.23+ API; the admin login route has moved to /api/admins/auth-with-password (and other routes are similar)

It would appear that all the tests are passing, but many are skipped despite a running local pocketbase installation.  Clearly I am missing something, but it appears to work running it against my development instance on the cloud.  