### PR TITLE
Dictionary Seralization for Record Class via to_dict

### DIFF
--- a/pocketbase/models/record.py
+++ b/pocketbase/models/record.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
-
-import json
 from typing import Any
-
 from pocketbase.models.utils.base_model import BaseModel
 from pocketbase.utils import camel_to_snake
 
@@ -34,59 +31,46 @@ class Record(BaseModel):
         for key, value in self.expand.items():
             self.expand[key] = self.parse_expanded(value)
 
-    def _snake_to_camel(self, name: str) -> str:
-        """Convert snake_case to camelCase (reverse of camel_to_snake)."""
-        if '_' not in name:
-            return name
-        parts = name.split('_')
-        return parts[0] + ''.join(word.capitalize() for word in parts[1:])
-
     def to_dict(self) -> dict[str, Any]:
         """
         Returns a dictionary representation of the Record that can be serialized to JSON.
-        
+
         This method serializes all attributes of the Record, including:
         - Base attributes (id, created, updated).
         - Collection attributes (collectionId, collectionName).
         - Expand data.
         - All dynamic attributes set during the load method.
-        
+
         Returns:
             dict[str, Any]: Dictionary representation of the Record.
         """
         data = {}
-        
+
         # Add base attributes
-        data['id'] = self.id
-        data['created'] = self.created.isoformat() if hasattr(self.created, 'isoformat') else str(self.created)
-        data['updated'] = self.updated.isoformat() if hasattr(self.updated, 'isoformat') else str(self.updated)
-        
+        data["id"] = self.id
+        data["created"] = (
+            self.created.isoformat()
+            if hasattr(self.created, "isoformat")
+            else str(self.created)
+        )
+        data["updated"] = (
+            self.updated.isoformat()
+            if hasattr(self.updated, "isoformat")
+            else str(self.updated)
+        )
+
         # Add expand data
-        data['expand'] = self.expand
-        
+        data["expand"] = self.expand
+
         # Add all other dynamic attributes (excluding special attributes)
-        exclude_attrs = {'id', 'created', 'updated', 'expand', 'client'}
+        exclude_attrs = {"id", "created", "updated", "expand", "client"}
         for attr_name in dir(self):
-            if not attr_name.startswith('_') and attr_name not in exclude_attrs:
+            if not attr_name.startswith("_") and attr_name not in exclude_attrs:
                 try:
                     attr_value = getattr(self, attr_name)
                     if not callable(attr_value):
-                        # Use the same auto_snake_case setting as the client for consistency
-                        auto_snake_case = (
-                            getattr(self, "client", None) 
-                            and getattr(self.client, "auto_snake_case", True)
-                        )
-                        
-                        if auto_snake_case and '_' in attr_name:
-                            # Convert snake_case back to camelCase for JSON output
-                            json_key = self._snake_to_camel(attr_name)
-                        else:
-                            # Keep original format
-                            json_key = attr_name
-                            
-                        data[json_key] = attr_value
+                        data[attr_name] = attr_value
                 except (AttributeError, TypeError):
                     # Skip attributes that can't be accessed or serialized
                     continue
-        
         return data


### PR DESCRIPTION
Attempts to implement feature functionality as requested in #33 based on #27 but was reverted in #42.

Resolves #27.

Disclosure: I used an AI agent to generate this code.

Here is my working example which provides a dict of the Record:

```python
import pocketbase
client = pocketbase.PocketBase("http://127.0.0.1:8090")
admin_data = client.collection("users").auth_with_password("molecule@example.com", "molecule")
print(admin_data.is_valid)
records = client.collection("systems").get_full_list(query_params={"sort": "created"})
print(records[0].to_dict())
```

```
{'id': 'q5y5h742bwueyns', 'created': '2025-08-30T07:48:04', 'updated': '2025-08-30T10:53:36', 'expand': {}, 'collectionId': '2hz5ncl8tizk5nx', 'collectionName': 'systems', 'host': 'instance', 'info': {'h': '90ba6044d626', 'k': '6.15.11-orbstack-00539-g9885ebd8e3f4', 'c': 10, 't': 10, 'm': '', 'u': 28181, 'cpu': 0.06, 'mp': 2.05, 'dp': 4.09, 'b': 0, 'v': '0.12.6', 'os': 0, 'l5': 0.01, 'bb': 40, 'la': [0, 0.01, 0]}, 'is_new': False, 'name': 'instance', 'port': '45876', 'status': 'up', 'users': ['zsk3bb1p2uisg4g']}
```