### PR TITLE
Fix retrieval of auth_providers from PocketBase >= 0.37.0

### DIFF
--- a/src/pocketbase/services/record_service.py
+++ b/src/pocketbase/services/record_service.py
@@ -43,6 +43,7 @@ class AuthProviderInfo:
     code_verifier: str
     code_challenge: str
     code_challenge_method: str
+    logo: str | None
 
 
 @dataclass

--- a/src/pocketbase/services/record_service.py
+++ b/src/pocketbase/services/record_service.py
@@ -43,7 +43,7 @@ class AuthProviderInfo:
     code_verifier: str
     code_challenge: str
     code_challenge_method: str
-    logo: str | None
+    logo = ""
 
 
 @dataclass


### PR DESCRIPTION
listAuthMethods() (aka. /api/collection/{col}/auth-methods) now returns the OAuth2 provider logo for each provider as inlined SVG string in its response data

default necessary to handle previous versions